### PR TITLE
RPM normalization bug fix + usability improvement

### DIFF
--- a/R/metagene.R
+++ b/R/metagene.R
@@ -728,6 +728,7 @@ metagene <- R6Class("metagene",
             i <- vapply(grl, length, numeric(1)) > 0
             m <- do.call("rbind", lapply(grl[i], private$get_view_means,
                                          bcount = bcount, cov = coverages))
+            m[GenomicRanges::findOverlaps(gr, unlist(grl), select="first"),]
         },
         get_view_means = function(gr, bcount, cov) {
             chr <- unique(as.character(GenomeInfoDb::seqnames(gr)))

--- a/R/metagene.R
+++ b/R/metagene.R
@@ -874,7 +874,7 @@ metagene <- R6Class("metagene",
                 bam_files <- as.character(design[,1][which_rows])
                 counts <- lapply(bam_files,
                                  private$bam_handler$get_aligned_count)
-                count <- do.call("+", counts)
+                count <- sum(unlist(counts))
                 weight <- 1 / (count / 1000000)
                 coverages[[design_name]] <- coverages[[design_name]] * weight
             }

--- a/R/metagene.R
+++ b/R/metagene.R
@@ -870,7 +870,8 @@ metagene <- R6Class("metagene",
         },
         normalize_coverages = function(coverages, design) {
             for (design_name in colnames(design)[-1]) {
-                bam_files <- as.character(design[,1][1])
+                which_rows = design[[design_name]]==1
+                bam_files <- as.character(design[,1][which_rows])
                 counts <- lapply(bam_files,
                                  private$bam_handler$get_aligned_count)
                 count <- do.call("+", counts)


### PR DESCRIPTION
There was a bug which caused RPM normalization to be innaccurate: all coverages were normalized against the read count of the very first bam file in the design matrix, rather than the total read count of all bam files implied in the current contrast/condition. This fixes it.

I've also made a slight usability improvement, in that produce_matrices now returns coverages in the same order as the metagene regions, rather than jumbling them up. This is useful when you want to use per-region coverage values for a secondary analysis.