### PR TITLE
Allow bam index files named file.bai in addition to file.bam.bai

### DIFF
--- a/R/metagene.R
+++ b/R/metagene.R
@@ -14,7 +14,8 @@
 #'                    object.}
 #'     \item{bam_files}{A \code{vector} of BAM filenames. The BAM files must be
 #'                      indexed. i.e.: if a file is named file.bam, there must
-#'                      be a file named file.bam.bai in the same directory.}
+#'                      be a file named file.bam.bai or file.bai in the same 
+#'                      directory.}
 #'     \item{padding_size}{The regions will be extended on each side by the
 #'                         value of this parameter. The padding_size must be a
 #'                         non-negative integer. Default = 0.}
@@ -549,9 +550,6 @@ metagene <- R6Class("metagene",
             }
             if (!all(sapply(bam_files, file.exists))) {
                 stop("At least one BAM file does not exist")
-            }
-            if (!all(sapply(paste0(bam_files, ".bai"), file.exists))) {
-                stop("All BAM files must be indexed")
             }
             if (!is(regions, "GRangesList") && !is.character(regions)
                 && !is(regions, "GRanges") && !is.list(regions)) {

--- a/man/Bam_Handler.Rd
+++ b/man/Bam_Handler.Rd
@@ -22,7 +22,8 @@ files/data.
     \item{}{\code{bh <- Bam_Handler$new(bam_files, cores = SerialParam())}}
     \item{bam_files}{A \code{vector} of BAM filenames. The BAM files must be
                      indexed. i.e.: if a file is named file.bam, there must
-                     be a file named file.bam.bai in the same directory.}
+                     be a file named file.bam.bai or file.bai in the same 
+                     directory.}
     \item{cores}{The number of cores available to parallelize the analysis.
                  Either a positive integer or a \code{BiocParallelParam}.
                  Default: \code{SerialParam()}.}

--- a/man/metagene.Rd
+++ b/man/metagene.Rd
@@ -28,7 +28,8 @@ metagene plots on the data (or a subset of the data).
                    object.}
     \item{bam_files}{A \code{vector} of BAM filenames. The BAM files must be
                      indexed. i.e.: if a file is named file.bam, there must
-                     be a file named file.bam.bai in the same directory.}
+                     be a file named file.bam.bai or file.bai in the same 
+                     directory.}
     \item{padding_size}{The regions will be extended on each side by the
                         value of this parameter. The padding_size must be a
                         non-negative integer. Default = 0.}

--- a/vignettes/metagene.Rmd
+++ b/vignettes/metagene.Rmd
@@ -50,7 +50,7 @@ library(metagene)
 There is no hard limit in the number of BAM files that can be included in an
 analysis (but with too many BAM files, memory may become an issue). BAM files
 must be indexed. For instance, if you use a file names `file.bam`, a file
-named `file.bam.bai` must be present in the same directory.
+named `file.bam.bai` or `file.bai`must be present in the same directory.
 
 The path (relative or absolute) to the BAM files must be in a vector:
 ```{r bamFiles}


### PR DESCRIPTION
Simple quality fo life improvement, since lots of people/pipelines name the index file of foo.bam "foo.bai" instead of "foo.bam.bai".